### PR TITLE
Phase 5: timezone override, direct conversion, and configurable messaging

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,3 +23,6 @@ NODE_ENV=production
 
 # Optional log level override (debug, info, warn, error)
 # LOG_LEVEL=info
+
+# Conversion message visibility for single-workspace mode (public or ephemeral)
+# CONVERSION_MESSAGE_VISIBILITY=public

--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ Right now this is done automatically for everyone, but we are planning on adding
 
 ## Future Plans
 
-- [ ] Add in-text timezone overriding
-- [ ] Add direct time conversion via App Mentioning or Slash Commands
-- [ ] Add configurable messaging
+- [x] Add in-text timezone overriding
+- [x] Add direct time conversion via App Mentioning or Slash Commands
+- [x] Add configurable messaging

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import * as Middleware from './middleware';
 import * as Controllers from './controller';
 import { createSlackApp, createFirebase } from './client';
 import { loadEnv, createLogger, setLogger, getLogger } from './config';
+import { initWorkspaceSettings } from './service/workspaceSettings';
 import type { App } from '@slack/bolt';
 
 export default async function main() {
@@ -10,6 +11,7 @@ export default async function main() {
     setLogger(logger);
 
     const db = createFirebase(env, logger);
+    initWorkspaceSettings(db, env);
     const { slackBoltApp } = createSlackApp(db, env, logger);
 
     await slackBoltApp.start(env.PORT);
@@ -28,10 +30,16 @@ const registerEventHandlers = (slackBoltApp: App) => {
 
     slackBoltApp.message(Middleware.preventBotMessages, Middleware.messageHasTimeRef, Controllers.promptMsgDateConvert);
 
+    slackBoltApp.event('app_mention', Controllers.handleAppMention);
+
+    slackBoltApp.command('/convert', Controllers.handleConvertCommand);
+
     slackBoltApp.action({ action_id: 'convert_date' }, Controllers.convertTimeInChannel);
 
     slackBoltApp.action({ action_id: 'dismiss_convert' }, async ({ ack, respond }) => {
         await ack();
         await respond({ delete_original: true });
     });
+
+    slackBoltApp.action({ action_id: 'set_conversion_visibility' }, Controllers.updateConversionVisibility);
 };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -10,6 +10,7 @@ const envSchema = z.object({
     GOOGLE_APPLICATION_CREDENTIALS: z.string().optional(),
     FIREBASE_PROJECT_ID: z.string().default('slack-in-your-time'),
     LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).optional(),
+    CONVERSION_MESSAGE_VISIBILITY: z.enum(['public', 'ephemeral']).default('public'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/config/token-scope.json
+++ b/src/config/token-scope.json
@@ -4,6 +4,7 @@
     "channels:read",
     "chat:write",
     "chat:write.public",
+    "commands",
     "groups:history",
     "groups:read",
     "groups:write",

--- a/src/controller/convertDateMessage.ts
+++ b/src/controller/convertDateMessage.ts
@@ -9,6 +9,7 @@ import { EventContext } from '../model';
 import * as Helpers from '../helper';
 import * as Views from '../view';
 import { getLogger } from '../config';
+import { getWorkspaceSettings } from '../service/workspaceSettings';
 import _ from 'lodash';
 
 /**
@@ -60,6 +61,8 @@ export const convertTimeInChannel: Middleware<SlackActionMiddlewareArgs<BlockAct
     ack,
     respond,
     say,
+    client,
+    context,
 }) => {
     const action = 'convert_date';
     await ack();
@@ -73,26 +76,28 @@ export const convertTimeInChannel: Middleware<SlackActionMiddlewareArgs<BlockAct
         };
 
         const senderTimezone = Helpers.assertValidTimezone(actionData.timeContext.content[0].tz);
-
-        const channelTimezones = _.filter(actionData.payload, (timezone) => timezone !== senderTimezone);
-
-        const convertedTimes = channelTimezones.map((timezone) => {
-            const localTime = actionData.timeContext.content.map((reference) => {
-                const start = Helpers.convertInstantToZone(reference.start, timezone);
-
-                return {
-                    start,
-                    tz: timezone,
-                } as EventContext.DateReference;
-            });
-            return localTime;
-        });
-
+        const convertedTimes = Helpers.convertTimeAcrossChannel(actionData.timeContext, actionData.payload);
         const messageContent = Views.convertedTimesBlock(senderTimezone, convertedTimes);
 
         await respond({
             delete_original: true,
         });
+
+        const teamId = context.teamId ?? body.team?.id ?? '';
+        const settings = await getWorkspaceSettings(teamId);
+        const channel = actionData.timeContext.sentChannel;
+        const userId = actionData.timeContext.senderId;
+
+        if (settings.conversionVisibility === 'ephemeral') {
+            await Helpers.sendEphemeralMessage(client, {
+                text: 'time conversion message',
+                blocks: messageContent,
+                channel,
+                user: userId,
+                token: context.botToken,
+            });
+            return;
+        }
 
         await say({
             text: 'time conversion message',

--- a/src/controller/directConvert.ts
+++ b/src/controller/directConvert.ts
@@ -1,0 +1,200 @@
+import { Middleware, SlackEventMiddlewareArgs, SlackCommandMiddlewareArgs } from '@slack/bolt';
+import * as Helpers from '../helper';
+import * as Views from '../view';
+import { getLogger } from '../config';
+import { getWorkspaceSettings } from '../service/workspaceSettings';
+import _ from 'lodash';
+
+type SlackBlocks = ReturnType<typeof Views.convertedTimesBlock>;
+type SlackClient = Parameters<typeof Helpers.getConversationMembers>[0];
+
+const stripBotMention = (text: string): string => {
+    return text.replace(/<@[A-Z0-9]+>/g, '').trim();
+};
+
+const postConversionResult = async (
+    visibility: 'public' | 'ephemeral',
+    args: {
+        client: SlackClient;
+        channel: string;
+        userId: string;
+        token: string;
+        blocks: SlackBlocks;
+        say: (message: { text: string; blocks: SlackBlocks }) => Promise<unknown>;
+    },
+): Promise<void> => {
+    const message = { text: 'time conversion message', blocks: args.blocks };
+
+    if (visibility === 'ephemeral') {
+        await Helpers.sendEphemeralMessage(args.client, {
+            ...message,
+            channel: args.channel,
+            user: args.userId,
+            token: args.token,
+        });
+        return;
+    }
+
+    await args.say(message);
+};
+
+/**
+ * Converts time references from an app mention and posts the result directly.
+ */
+export const handleAppMention: Middleware<SlackEventMiddlewareArgs<'app_mention'>> = async ({
+    event,
+    client,
+    context,
+    say,
+}) => {
+    try {
+        const userId = event.user;
+        const channelId = event.channel;
+        const token = context.botToken;
+
+        if (!userId || !channelId || !token) return;
+
+        const text = stripBotMention(event.text);
+        if (!text) return;
+
+        const timeContext = await Helpers.createMessageTimeContext(
+            client,
+            token,
+            userId,
+            channelId,
+            text,
+            event.ts ? Math.floor(parseFloat(event.ts)) : Math.floor(Date.now() / 1000),
+        );
+
+        if (!timeContext) {
+            await Helpers.sendEphemeralMessage(client, {
+                text: 'I could not find a time reference in your message. Try something like "meeting at 3pm tomorrow".',
+                channel: channelId,
+                user: userId,
+                token,
+            });
+            return;
+        }
+
+        const channelMembers = await Helpers.getConversationMembers(client, channelId, token);
+        const channelTimezones = _.filter(
+            Helpers.getUserTimeZones(channelMembers),
+            (timezone) => timezone !== timeContext.content[0].tz,
+        );
+
+        if (channelTimezones.length === 0) {
+            await Helpers.sendEphemeralMessage(client, {
+                text: 'Everyone in this channel appears to share the same timezone.',
+                channel: channelId,
+                user: userId,
+                token,
+            });
+            return;
+        }
+
+        const convertedTimes = Helpers.convertTimeAcrossChannel(timeContext, channelTimezones);
+        const blocks = Views.convertedTimesBlock(timeContext.content[0].tz, convertedTimes);
+        const teamId = context.teamId ?? '';
+        const settings = await getWorkspaceSettings(teamId);
+
+        await postConversionResult(settings.conversionVisibility, {
+            client,
+            channel: channelId,
+            userId,
+            token,
+            blocks,
+            say,
+        });
+    } catch (err) {
+        getLogger().error({ err, channel: event.channel }, 'Failed to handle app mention conversion');
+    }
+};
+
+/**
+ * Slash command handler for direct time conversion.
+ */
+export const handleConvertCommand: Middleware<SlackCommandMiddlewareArgs> = async ({
+    command,
+    ack,
+    client,
+    context,
+    respond,
+}) => {
+    await ack();
+
+    try {
+        const token = context.botToken;
+        if (!token) {
+            await respond({ response_type: 'ephemeral', text: 'Bot token not available.' });
+            return;
+        }
+
+        const text = command.text.trim();
+        if (!text) {
+            await respond({
+                response_type: 'ephemeral',
+                text: 'Usage: `/convert <time expression>` — e.g. `/convert 3pm tomorrow EST`',
+            });
+            return;
+        }
+
+        const timeContext = await Helpers.createMessageTimeContext(
+            client,
+            token,
+            command.user_id,
+            command.channel_id,
+            text,
+            Math.floor(Date.now() / 1000),
+        );
+
+        if (!timeContext) {
+            await respond({
+                response_type: 'ephemeral',
+                text: 'I could not find a time reference. Try something like `/convert 3pm tomorrow`.',
+            });
+            return;
+        }
+
+        const channelMembers = await Helpers.getConversationMembers(client, command.channel_id, token);
+        const channelTimezones = _.filter(
+            Helpers.getUserTimeZones(channelMembers),
+            (timezone) => timezone !== timeContext.content[0].tz,
+        );
+
+        if (channelTimezones.length === 0) {
+            await respond({
+                response_type: 'ephemeral',
+                text: 'Everyone in this channel appears to share the same timezone.',
+            });
+            return;
+        }
+
+        const convertedTimes = Helpers.convertTimeAcrossChannel(timeContext, channelTimezones);
+        const blocks = Views.convertedTimesBlock(timeContext.content[0].tz, convertedTimes);
+        const teamId = context.teamId ?? command.team_id;
+        const settings = await getWorkspaceSettings(teamId);
+
+        if (settings.conversionVisibility === 'ephemeral') {
+            await Helpers.sendEphemeralMessage(client, {
+                text: 'time conversion message',
+                blocks,
+                channel: command.channel_id,
+                user: command.user_id,
+                token,
+            });
+            return;
+        }
+
+        await respond({
+            response_type: 'in_channel',
+            text: 'time conversion message',
+            blocks,
+        });
+    } catch (err) {
+        getLogger().error({ err, channel: command.channel_id }, 'Failed to handle /convert command');
+        await respond({
+            response_type: 'ephemeral',
+            text: `Something went wrong: ${(err as Error).message}`,
+        });
+    }
+};

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -1,2 +1,4 @@
 export * from './convertDateMessage';
 export * from './renderAppHome';
+export * from './directConvert';
+export * from './workspaceSettings';

--- a/src/controller/renderAppHome.ts
+++ b/src/controller/renderAppHome.ts
@@ -2,17 +2,28 @@ import { Middleware, SlackEventMiddlewareArgs } from '@slack/bolt';
 import * as View from '../view';
 import { Users } from '../model';
 import { getLogger } from '../config';
+import { getWorkspaceSettings, isSettingsEditable } from '../service/workspaceSettings';
 
-export const displayAppHomeTab: Middleware<SlackEventMiddlewareArgs<'app_home_opened'>> = async ({ client, event }) => {
+export const displayAppHomeTab: Middleware<SlackEventMiddlewareArgs<'app_home_opened'>> = async ({
+    client,
+    event,
+    context,
+}) => {
     try {
         const userId = event.user;
+        const teamId = context.teamId ?? '';
 
         const userInfo = (await client.users.info({
             user: userId,
             include_locale: true,
         })) as Users.InfoResponse;
 
-        const homeBlock = View.appHomeBlock({ userInfo: userInfo.user });
+        const settings = await getWorkspaceSettings(teamId);
+        const homeBlock = View.appHomeBlock({
+            userInfo: userInfo.user,
+            settings,
+            settingsEditable: isSettingsEditable(),
+        });
 
         await client.views.publish({
             user_id: userId,

--- a/src/controller/workspaceSettings.ts
+++ b/src/controller/workspaceSettings.ts
@@ -1,0 +1,45 @@
+import { Middleware, SlackActionMiddlewareArgs, BlockAction, StaticSelectAction } from '@slack/bolt';
+import { getLogger } from '../config';
+import {
+    getWorkspaceSettings,
+    saveWorkspaceSettings,
+    ConversionVisibility,
+    isSettingsEditable,
+} from '../service/workspaceSettings';
+import * as View from '../view';
+import { Users } from '../model';
+
+export const updateConversionVisibility: Middleware<
+    SlackActionMiddlewareArgs<BlockAction<StaticSelectAction>>
+> = async ({ body, ack, client, action }) => {
+    await ack();
+
+    try {
+        const teamId = body.team?.id;
+        const userId = body.user.id;
+
+        if (!teamId) throw new Error('Team ID not found in action payload');
+        if (!isSettingsEditable()) throw new Error('Workspace settings are not editable in this deployment');
+
+        const visibility = action.selected_option.value as ConversionVisibility;
+        await saveWorkspaceSettings(teamId, { conversionVisibility: visibility });
+
+        const userInfo = (await client.users.info({ user: userId, include_locale: true })) as Users.InfoResponse;
+        const settings = await getWorkspaceSettings(teamId);
+        const homeBlock = View.appHomeBlock({
+            userInfo: userInfo.user,
+            settings,
+            settingsEditable: true,
+        });
+
+        await client.views.publish({
+            user_id: userId,
+            view: {
+                type: 'home',
+                blocks: homeBlock,
+            },
+        });
+    } catch (err) {
+        getLogger().error({ err }, 'Failed to update conversion visibility setting');
+    }
+};

--- a/src/helper/convertTime.ts
+++ b/src/helper/convertTime.ts
@@ -1,0 +1,18 @@
+import _ from 'lodash';
+import { EventContext } from '../model';
+import { assertValidTimezone, convertInstantToZone } from './timezone';
+
+export const convertTimeAcrossChannel = (
+    timeContext: EventContext.MessageTimeContext,
+    channelTimezones: string[],
+): EventContext.DateReference[][] => {
+    const senderTimezone = assertValidTimezone(timeContext.content[0].tz);
+    const targetTimezones = _.filter(channelTimezones, (timezone) => timezone !== senderTimezone);
+
+    return targetTimezones.map((timezone) =>
+        timeContext.content.map((reference) => ({
+            start: convertInstantToZone(reference.start, timezone),
+            tz: timezone,
+        })),
+    );
+};

--- a/src/helper/detectTimezoneInText.ts
+++ b/src/helper/detectTimezoneInText.ts
@@ -1,0 +1,74 @@
+import { IANAZone } from 'luxon';
+import { assertValidTimezone } from './timezone';
+
+const IANA_PATTERN = /\b([A-Za-z]+(?:\/[A-Za-z_]+)+)\b/g;
+
+/** Common timezone abbreviations mapped to IANA zones (US-centric where ambiguous). */
+const ABBREVIATION_TO_IANA: Record<string, string> = {
+    UTC: 'UTC',
+    GMT: 'Etc/GMT',
+    EST: 'America/New_York',
+    EDT: 'America/New_York',
+    CST: 'America/Chicago',
+    CDT: 'America/Chicago',
+    MST: 'America/Denver',
+    MDT: 'America/Denver',
+    PST: 'America/Los_Angeles',
+    PDT: 'America/Los_Angeles',
+    JST: 'Asia/Tokyo',
+    KST: 'Asia/Seoul',
+    IST: 'Asia/Kolkata',
+    CET: 'Europe/Paris',
+    CEST: 'Europe/Paris',
+    BST: 'Europe/London',
+    AEST: 'Australia/Sydney',
+    AEDT: 'Australia/Sydney',
+    HKT: 'Asia/Hong_Kong',
+    SGT: 'Asia/Singapore',
+};
+
+export interface DetectedTimezone {
+    timezone: string;
+    strippedMessage: string;
+}
+
+const findIanaTimezone = (message: string): DetectedTimezone | null => {
+    const matches = [...message.matchAll(IANA_PATTERN)];
+
+    for (const match of matches) {
+        const candidate = match[1];
+        if (IANAZone.isValidZone(candidate)) {
+            const strippedMessage = message.replace(match[0], ' ').replace(/\s+/g, ' ').trim();
+            return { timezone: assertValidTimezone(candidate), strippedMessage };
+        }
+    }
+
+    return null;
+};
+
+const findAbbreviationTimezone = (message: string): DetectedTimezone | null => {
+    const abbreviationPattern = /\b([A-Z]{2,4})\b/g;
+    const matches = [...message.matchAll(abbreviationPattern)];
+
+    for (const match of matches) {
+        const abbreviation = match[1];
+        const iana = ABBREVIATION_TO_IANA[abbreviation];
+        if (!iana) continue;
+
+        const strippedMessage = message
+            .replace(new RegExp(`\\b${abbreviation}\\b`), ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+        return { timezone: assertValidTimezone(iana), strippedMessage };
+    }
+
+    return null;
+};
+
+/**
+ * Detects an explicit timezone in message text (IANA label or common abbreviation).
+ * Returns the resolved IANA zone and the message with the timezone token removed.
+ */
+export const detectTimezoneInText = (message: string): DetectedTimezone | null => {
+    return findIanaTimezone(message) ?? findAbbreviationTimezone(message);
+};

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -4,3 +4,6 @@ export * from './formatTimeMsg';
 export * from './webClientFetch';
 export * from './nonceGenerator';
 export * from './timezone';
+export * from './detectTimezoneInText';
+export * from './convertTime';
+export * from './timeContext';

--- a/src/helper/parseTextTime.ts
+++ b/src/helper/parseTextTime.ts
@@ -2,36 +2,35 @@ import * as chrono from 'chrono-node';
 import _ from 'lodash';
 import { EventContext } from '../model';
 import { chronoReferenceFromSenderZone, dateFromChronoInZone } from './timezone';
+import { detectTimezoneInText } from './detectTimezoneInText';
 
 /**
  * Parses the given message string to determine the full date that it is referencing to.
+ * When the message contains an explicit timezone (IANA label or abbreviation), that zone
+ * is used instead of the sender's profile timezone.
  * @param messageText the string message to parse
  * @param sentTime the time when the event was sent. This is the event timestamp in unix epoch
  * @param senderTimezone IANA timezone for the message sender
  */
 export const parseTimeReference = (messageText: string, sentTime: number, senderTimezone: string) => {
-    const referenceDate = chronoReferenceFromSenderZone(sentTime, senderTimezone);
-    const parsedDate = messageToTime(messageText, referenceDate);
+    const detected = detectTimezoneInText(messageText);
+    const effectiveTimezone = detected?.timezone ?? senderTimezone;
+    const textToParse = detected?.strippedMessage ?? messageText;
+
+    const referenceDate = chronoReferenceFromSenderZone(sentTime, effectiveTimezone);
+    const parsedDate = chrono.casual.parse(textToParse, referenceDate);
 
     if (!parsedDate || parsedDate.length < 1) return [];
 
     const timeContext = _.map(parsedDate, (res) => {
-        const start = dateFromChronoInZone(res.start.date(), senderTimezone);
-        const tz = senderTimezone;
+        const start = dateFromChronoInZone(res.start.date(), effectiveTimezone);
 
         return {
             sourceMsg: messageText,
             start,
-            tz,
+            tz: effectiveTimezone,
         } as EventContext.LocalDateReference;
     });
 
     return timeContext;
-};
-
-const messageToTime = (msg: string, sourceDate?: Date) => {
-    // todo: improve this function so that if the message contains a timezone label, we can override the source date
-    const parsedDate = chrono.casual.parse(msg, sourceDate);
-
-    return parsedDate;
 };

--- a/src/helper/timeContext.ts
+++ b/src/helper/timeContext.ts
@@ -1,0 +1,31 @@
+import { webApi } from '@slack/bolt';
+import { Users, EventContext } from '../model';
+import { parseTimeReference } from './parseTextTime';
+import { resolveTimezone } from './timezone';
+
+export const createMessageTimeContext = async (
+    client: webApi.WebClient,
+    token: string | undefined,
+    userId: string,
+    channelId: string,
+    text: string,
+    sentTime: number,
+): Promise<EventContext.MessageTimeContext | null> => {
+    const userInfo = (await client.users.info({
+        token,
+        user: userId,
+        include_locale: true,
+    })) as Users.InfoResponse;
+
+    const senderTimezone = resolveTimezone(userInfo.user.tz);
+    const parsedTime = parseTimeReference(text, sentTime, senderTimezone);
+
+    if (!parsedTime || parsedTime.length < 1) return null;
+
+    return {
+        senderId: userId,
+        sentChannel: channelId,
+        content: parsedTime,
+        sentTime,
+    };
+};

--- a/src/middleware/messageListener.ts
+++ b/src/middleware/messageListener.ts
@@ -55,5 +55,3 @@ export const messageHasTimeRef: Middleware<SlackEventMiddlewareArgs<'message'>> 
         getLogger().debug({ err, eventId: body.event_id }, 'Skipping message event');
     }
 };
-
-// todo: add behavior for when the user references the bot with the `@` symbol

--- a/src/service/workspaceSettings.ts
+++ b/src/service/workspaceSettings.ts
@@ -1,0 +1,48 @@
+import type { Firestore } from '@google-cloud/firestore';
+import type { Env } from '../config/env';
+
+export type ConversionVisibility = 'public' | 'ephemeral';
+
+export interface WorkspaceSettings {
+    conversionVisibility: ConversionVisibility;
+}
+
+const COLLECTION = 'workspace-settings';
+const DEFAULT_SETTINGS: WorkspaceSettings = { conversionVisibility: 'public' };
+
+let settingsDb: Firestore | null = null;
+let settingsEnv: Env | null = null;
+
+export const initWorkspaceSettings = (db: Firestore | null, env: Env): void => {
+    settingsDb = db;
+    settingsEnv = env;
+};
+
+export const isSettingsEditable = (): boolean => settingsDb !== null;
+
+const visibilityFromEnv = (): ConversionVisibility => {
+    const value = settingsEnv?.CONVERSION_MESSAGE_VISIBILITY;
+    return value === 'ephemeral' ? 'ephemeral' : 'public';
+};
+
+export const getWorkspaceSettings = async (teamId: string): Promise<WorkspaceSettings> => {
+    if (!settingsDb) {
+        return { conversionVisibility: visibilityFromEnv() };
+    }
+
+    const doc = await settingsDb.collection(COLLECTION).doc(teamId).get();
+    if (!doc.exists) return DEFAULT_SETTINGS;
+
+    const data = doc.data() as Partial<WorkspaceSettings> | undefined;
+    const visibility = data?.conversionVisibility === 'ephemeral' ? 'ephemeral' : 'public';
+
+    return { conversionVisibility: visibility };
+};
+
+export const saveWorkspaceSettings = async (teamId: string, settings: WorkspaceSettings): Promise<void> => {
+    if (!settingsDb) {
+        throw new Error('Workspace settings require Firebase in multi-workspace mode');
+    }
+
+    await settingsDb.collection(COLLECTION).doc(teamId).set(settings, { merge: true });
+};

--- a/src/view/appHomeBlock.ts
+++ b/src/view/appHomeBlock.ts
@@ -1,14 +1,65 @@
 import { DateTime } from 'luxon';
 import { Users } from '../model';
 import { getLocalTimezone } from '../helper/timezone';
+import type { WorkspaceSettings } from '../service/workspaceSettings';
 
 interface HomeBlockProps {
     userInfo: Users.User;
+    settings: WorkspaceSettings;
+    settingsEditable: boolean;
 }
 
 export const appHomeBlock = (props: HomeBlockProps) => {
     const timezone = props.userInfo.tz || getLocalTimezone();
     const time = DateTime.now().setZone(timezone);
+
+    const visibilityOptions = [
+        {
+            text: { type: 'plain_text' as const, text: 'Public — post conversions in the channel' },
+            value: 'public',
+        },
+        {
+            text: { type: 'plain_text' as const, text: 'Ephemeral — only visible to the person who triggered it' },
+            value: 'ephemeral',
+        },
+    ];
+
+    const settingsBlocks = props.settingsEditable
+        ? [
+              {
+                  type: 'divider' as const,
+              },
+              {
+                  type: 'section' as const,
+                  text: {
+                      type: 'mrkdwn' as const,
+                      text: '*Workspace settings*\nChoose how converted times are posted after confirmation or direct conversion.',
+                  },
+                  accessory: {
+                      type: 'static_select' as const,
+                      action_id: 'set_conversion_visibility',
+                      placeholder: {
+                          type: 'plain_text' as const,
+                          text: 'Conversion visibility',
+                      },
+                      initial_option: visibilityOptions.find(
+                          (option) => option.value === props.settings.conversionVisibility,
+                      ),
+                      options: visibilityOptions,
+                  },
+              },
+          ]
+        : [
+              {
+                  type: 'context' as const,
+                  elements: [
+                      {
+                          type: 'mrkdwn' as const,
+                          text: `Conversion messages are set to *${props.settings.conversionVisibility}* via server configuration.`,
+                      },
+                  ],
+              },
+          ];
 
     return [
         {
@@ -26,11 +77,19 @@ export const appHomeBlock = (props: HomeBlockProps) => {
                 emoji: true,
             },
         },
+        ...settingsBlocks,
         {
             type: 'section',
             text: {
                 type: 'mrkdwn',
-                text: 'This application is still working in progress. If you encounter any issues, please consider opening a bug report in Github.\nThank you for your support!',
+                text: '*Quick tips*\n• Mention me with a time: `@Slack In Your Time meeting at 3pm EST`\n• Use `/convert 3pm tomorrow` for direct conversion\n• Include a timezone in your message to override your profile zone',
+            },
+        },
+        {
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: 'Found a bug? Please open an issue on GitHub.',
             },
             accessory: {
                 type: 'button',

--- a/tests/messageParsing.test.ts
+++ b/tests/messageParsing.test.ts
@@ -1,3 +1,4 @@
+import { detectTimezoneInText } from '../src/helper/detectTimezoneInText';
 import * as Helpers from '../src/helper';
 import { DateTime } from 'luxon';
 
@@ -10,6 +11,26 @@ const formatDateString = (date: Date, zone: string) => {
 beforeAll(() => {
     process.env.SLACK_SIGNING_SECRET = 'my-test-secret';
     process.env.SLACK_BOT_TOKEN = 'my-test-token';
+});
+
+describe('detectTimezoneInText', () => {
+    it('should detect IANA timezone labels in message text', () => {
+        const result = detectTimezoneInText('meeting at 3pm America/New_York tomorrow');
+
+        expect(result?.timezone).toEqual('America/New_York');
+        expect(result?.strippedMessage).toEqual('meeting at 3pm tomorrow');
+    });
+
+    it('should detect common timezone abbreviations', () => {
+        const result = detectTimezoneInText('call at noon EST');
+
+        expect(result?.timezone).toEqual('America/New_York');
+        expect(result?.strippedMessage).toEqual('call at noon');
+    });
+
+    it('should return null when no timezone is present', () => {
+        expect(detectTimezoneInText('meeting at 3pm')).toBeNull();
+    });
 });
 
 describe('read time from message', () => {
@@ -33,6 +54,12 @@ describe('read time from message', () => {
         expect(casualParse).toHaveLength(2);
         expect(DateTime.fromJSDate(casualParse[0].start, { zone: senderTimezoneLabel }).day).toEqual(3);
         expect(DateTime.fromJSDate(casualParse[1].start, { zone: senderTimezoneLabel }).day).toEqual(9);
+    });
+
+    it('should override sender timezone when message includes an explicit zone', () => {
+        const parsedTime = Helpers.parseTimeReference('3pm EST', eventTimestamp, senderTimezoneLabel)[0];
+
+        expect(parsedTime.tz).toEqual('America/New_York');
     });
 });
 
@@ -68,5 +95,27 @@ describe('getUserTimeZones', () => {
         ]);
 
         expect(timezones).toEqual(['Asia/Tokyo', 'America/New_York']);
+    });
+});
+
+describe('convertTimeAcrossChannel', () => {
+    it('should convert parsed times to each channel timezone except the source', () => {
+        const timeContext = {
+            senderId: 'U1',
+            sentChannel: 'C1',
+            sentTime: 0,
+            content: [
+                {
+                    sourceMsg: '3pm',
+                    start: new Date('2021-05-02T18:00:00.000Z'),
+                    tz: 'America/New_York',
+                },
+            ],
+        };
+
+        const converted = Helpers.convertTimeAcrossChannel(timeContext, ['America/New_York', 'Asia/Tokyo']);
+
+        expect(converted).toHaveLength(1);
+        expect(converted[0][0].tz).toEqual('Asia/Tokyo');
     });
 });

--- a/tests/workspaceSettings.test.ts
+++ b/tests/workspaceSettings.test.ts
@@ -1,0 +1,30 @@
+import { initWorkspaceSettings, getWorkspaceSettings } from '../src/service/workspaceSettings';
+import { loadEnv } from '../src/config/env';
+
+describe('workspace settings', () => {
+    beforeEach(() => {
+        process.env.SLACK_SIGNING_SECRET = 'test-secret';
+        process.env.SLACK_CLIENT_ID = 'test-client';
+        process.env.SLACK_BOT_TOKEN = 'test-token';
+    });
+
+    it('should use env default visibility in single-workspace mode', async () => {
+        process.env.CONVERSION_MESSAGE_VISIBILITY = 'ephemeral';
+        const env = loadEnv();
+        initWorkspaceSettings(null, env);
+
+        const settings = await getWorkspaceSettings('T123');
+
+        expect(settings.conversionVisibility).toEqual('ephemeral');
+    });
+
+    it('should default to public visibility when env is unset', async () => {
+        delete process.env.CONVERSION_MESSAGE_VISIBILITY;
+        const env = loadEnv();
+        initWorkspaceSettings(null, env);
+
+        const settings = await getWorkspaceSettings('T123');
+
+        expect(settings.conversionVisibility).toEqual('public');
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Phase 5 from the upgrade roadmap — the three remaining items from the README Future Plans section.

### In-text timezone overriding

Messages can now include an explicit timezone (IANA label like `America/New_York` or common abbreviations like `EST`, `JST`, `UTC`). When detected, that zone is used for parsing instead of the sender's Slack profile timezone.

### Direct time conversion

- **App mentions**: `@Slack In Your Time meeting at 3pm EST` converts immediately without the confirmation prompt
- **`/convert` slash command**: `/convert 3pm tomorrow` for on-demand conversion in any channel

Both paths reuse the shared conversion helper and respect workspace visibility settings.

### Configurable messaging

Workspace admins can choose whether converted times are posted **publicly in the channel** or as **ephemeral messages** visible only to the person who triggered the conversion.

- **Multi-workspace (Firebase)**: setting stored in Firestore (`workspace-settings/{teamId}`) and editable from App Home
- **Single-workspace mode**: controlled via `CONVERSION_MESSAGE_VISIBILITY` env var (`public` | `ephemeral`, defaults to `public`)

The existing confirmation-button flow also respects this setting.

## Other changes

- Added `commands` OAuth scope for `/convert`
- App Home updated with quick tips and settings UI
- README Future Plans items marked complete
- 17 tests passing (6 new)

## Verification

```bash
yarn build && yarn test && yarn lint:check
```

## Post-merge setup

For existing installations, re-install or add the `commands` scope and register the `/convert` slash command in the Slack app config.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62d2f50e-bb30-4732-9c26-d5557206539b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62d2f50e-bb30-4732-9c26-d5557206539b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

