### PR TITLE
Phase 6: member-aware conversions and per-member delivery

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -25,4 +25,7 @@ NODE_ENV=production
 # LOG_LEVEL=info
 
 # Conversion message visibility for single-workspace mode (public or ephemeral)
-# CONVERSION_MESSAGE_VISIBILITY=public
+# CONVERSION_MESSAGE_VISIBILITY=public  # public, ephemeral, or per_member
+
+# Auto-convert channel messages without confirmation (true or false)
+# AUTO_CONVERT=false

--- a/README.md
+++ b/README.md
@@ -18,19 +18,64 @@ Until everyone is used to using Unix epoch time, we'll have to do something abou
 
 That is why we decided to make this Slack app.
 
-## Feature
+## Features
 
 ![bot-test-img](https://user-images.githubusercontent.com/40356749/124895038-3ab33b80-dfed-11eb-998c-612f3b882c42.jpg)
 
-This application is powered by the wonderful library for NLP date parsing that is [chrono](https://github.com/wanasit/chrono) and [bolt-js](https://github.com/SlackAPI/bolt-js).
+This application is powered by [chrono](https://github.com/wanasit/chrono) for natural-language date parsing and [bolt-js](https://github.com/SlackAPI/bolt-js) for Slack integration.
 
-Once you install this app to your Slack channel, it will listen to all text messages that references time.
-If your channel member has more than one time zone, this app will ask you if you would like to convert the time from your local time zone to all the member's time zone.
+Once installed, the bot listens for time references in channel messages and helps convert them across members' timezones.
 
-Right now this is done automatically for everyone, but we are planning on adding configurable behaviors like the ability to choose between public messages or messages only visible to the respective members.
+### Automatic channel detection
+
+When someone posts a message containing a time reference, the bot prompts the sender to convert it — unless auto-convert is enabled in workspace settings.
+
+### Direct conversion
+
+- **App mention**: `@Slack In Your Time meeting at 3pm EST`
+- **Slash command**: `/convert 3pm tomorrow`
+
+### In-text timezone override
+
+Include an IANA label (`America/New_York`) or abbreviation (`EST`, `JST`) in your message to parse the time in that zone instead of your Slack profile timezone.
+
+### Configurable delivery
+
+Workspace admins can configure how conversions are delivered (App Home tab):
+
+| Mode | Behavior |
+|------|----------|
+| **Public** | Post converted times in the channel |
+| **Ephemeral** | Only the person who triggered the conversion sees it |
+| **Per member** | Each channel member receives a private message with their local time |
+
+Auto-convert can also be toggled to skip the confirmation prompt on channel messages.
+
+## Self-hosting
+
+```bash
+cp .env.sample .env
+# Fill in Slack credentials; for multi-workspace OAuth, add Firebase credentials to secrets/
+
+docker compose up -d --build
+```
+
+See `.env.sample` for all configuration options including `CONVERSION_MESSAGE_VISIBILITY` and `AUTO_CONVERT` for single-workspace deployments.
+
+## Development
+
+```bash
+yarn install
+yarn dev
+yarn test
+yarn build
+```
+
+Requires Node 22+.
 
 ## Future Plans
 
 - [x] Add in-text timezone overriding
 - [x] Add direct time conversion via App Mentioning or Slash Commands
 - [x] Add configurable messaging
+- [x] Per-member private delivery and member-aware conversion output

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,4 +42,6 @@ const registerEventHandlers = (slackBoltApp: App) => {
     });
 
     slackBoltApp.action({ action_id: 'set_conversion_visibility' }, Controllers.updateConversionVisibility);
+
+    slackBoltApp.action({ action_id: 'set_auto_convert' }, Controllers.updateAutoConvert);
 };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -10,7 +10,11 @@ const envSchema = z.object({
     GOOGLE_APPLICATION_CREDENTIALS: z.string().optional(),
     FIREBASE_PROJECT_ID: z.string().default('slack-in-your-time'),
     LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).optional(),
-    CONVERSION_MESSAGE_VISIBILITY: z.enum(['public', 'ephemeral']).default('public'),
+    CONVERSION_MESSAGE_VISIBILITY: z.enum(['public', 'ephemeral', 'per_member']).default('public'),
+    AUTO_CONVERT: z
+        .enum(['true', 'false'])
+        .default('false')
+        .transform((value) => value === 'true'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/controller/convertDateMessage.ts
+++ b/src/controller/convertDateMessage.ts
@@ -10,17 +10,17 @@ import * as Helpers from '../helper';
 import * as Views from '../view';
 import { getLogger } from '../config';
 import { getWorkspaceSettings } from '../service/workspaceSettings';
-import _ from 'lodash';
+import { deliverConversion, prepareChannelConversion } from '../service/conversionDelivery';
 
 /**
  * Send a ephemeral message to the message sender to ask them if they want to convert their time.
- * The message block confirmation button contains the object for both the list channel members
- * and the message sender's time context.
+ * When auto-convert is enabled, performs conversion immediately without prompting.
  */
 export const promptMsgDateConvert: Middleware<SlackEventMiddlewareArgs<'message'>> = async ({
     context,
     body,
     client,
+    say,
 }) => {
     try {
         if (!context.message) throw new Error('Message context was not found');
@@ -29,25 +29,40 @@ export const promptMsgDateConvert: Middleware<SlackEventMiddlewareArgs<'message'
 
         const msgWithTime = context.message as EventContext.MessageTimeContext;
         const currentChannel = body.event.channel;
+        const teamId = context.teamId ?? body.team_id ?? '';
 
         const channelMembers = await Helpers.getConversationMembers(client, currentChannel, context.botToken);
+        const settings = await getWorkspaceSettings(teamId);
 
-        const channelTimezones = _.filter(
-            Helpers.getUserTimeZones(channelMembers),
-            (timezone) => timezone !== msgWithTime.content[0].tz,
-        );
+        const prepared = prepareChannelConversion(msgWithTime, channelMembers);
+        if (!prepared) return;
 
-        if (channelMembers.length > 0 && channelTimezones.length > 0) {
-            const confirmationForm = Views.userConfirmationMsgBox(msgWithTime, channelTimezones);
-
-            await Helpers.sendEphemeralMessage(client, {
-                text: 'confirmation message',
-                blocks: confirmationForm,
+        if (settings.autoConvert) {
+            await deliverConversion(settings.conversionVisibility, {
+                client,
                 channel: currentChannel,
-                user: msgWithTime.senderId,
+                triggerUserId: msgWithTime.senderId,
                 token: context.botToken,
+                timeContext: msgWithTime,
+                members: channelMembers,
+                sourceTimezone: prepared.sourceTimezone,
+                groups: prepared.groups,
+                blocks: prepared.blocks,
+                say,
             });
+            return;
         }
+
+        const channelTimezones = Helpers.uniqueChannelTimezones(prepared.groups);
+        const confirmationForm = Views.userConfirmationMsgBox(msgWithTime, channelTimezones);
+
+        await Helpers.sendEphemeralMessage(client, {
+            text: 'confirmation message',
+            blocks: confirmationForm,
+            channel: currentChannel,
+            user: msgWithTime.senderId,
+            token: context.botToken,
+        });
     } catch (err) {
         getLogger().warn({ err, channel: body.event.channel }, 'Failed to prompt timezone conversion');
     }
@@ -69,39 +84,38 @@ export const convertTimeInChannel: Middleware<SlackActionMiddlewareArgs<BlockAct
     try {
         const actionPayload = body.actions.find((i) => i.action_id === action)?.value;
         if (!actionPayload) throw new Error('could not find any data for action ' + action);
+        if (!context.botToken) throw new Error('No bot token was found');
 
         const actionData = JSON.parse(actionPayload) as {
             timeContext: EventContext.MessageTimeContext;
             payload: string[];
         };
 
-        const senderTimezone = Helpers.assertValidTimezone(actionData.timeContext.content[0].tz);
-        const convertedTimes = Helpers.convertTimeAcrossChannel(actionData.timeContext, actionData.payload);
-        const messageContent = Views.convertedTimesBlock(senderTimezone, convertedTimes);
+        const channelMembers = await Helpers.getConversationMembers(
+            client,
+            actionData.timeContext.sentChannel,
+            context.botToken,
+        );
 
-        await respond({
-            delete_original: true,
-        });
+        const prepared = prepareChannelConversion(actionData.timeContext, channelMembers);
+        if (!prepared) throw new Error('No timezone conversions available for this channel');
+
+        await respond({ delete_original: true });
 
         const teamId = context.teamId ?? body.team?.id ?? '';
         const settings = await getWorkspaceSettings(teamId);
-        const channel = actionData.timeContext.sentChannel;
-        const userId = actionData.timeContext.senderId;
 
-        if (settings.conversionVisibility === 'ephemeral') {
-            await Helpers.sendEphemeralMessage(client, {
-                text: 'time conversion message',
-                blocks: messageContent,
-                channel,
-                user: userId,
-                token: context.botToken,
-            });
-            return;
-        }
-
-        await say({
-            text: 'time conversion message',
-            blocks: messageContent,
+        await deliverConversion(settings.conversionVisibility, {
+            client,
+            channel: actionData.timeContext.sentChannel,
+            triggerUserId: actionData.timeContext.senderId,
+            token: context.botToken,
+            timeContext: actionData.timeContext,
+            members: channelMembers,
+            sourceTimezone: prepared.sourceTimezone,
+            groups: prepared.groups,
+            blocks: prepared.blocks,
+            say,
         });
     } catch (err) {
         getLogger().error({ err }, 'Failed to convert timezone message');

--- a/src/controller/directConvert.ts
+++ b/src/controller/directConvert.ts
@@ -1,41 +1,21 @@
 import { Middleware, SlackEventMiddlewareArgs, SlackCommandMiddlewareArgs } from '@slack/bolt';
 import * as Helpers from '../helper';
-import * as Views from '../view';
 import { getLogger } from '../config';
 import { getWorkspaceSettings } from '../service/workspaceSettings';
-import _ from 'lodash';
-
-type SlackBlocks = ReturnType<typeof Views.convertedTimesBlock>;
-type SlackClient = Parameters<typeof Helpers.getConversationMembers>[0];
+import { deliverConversion, prepareChannelConversion } from '../service/conversionDelivery';
 
 const stripBotMention = (text: string): string => {
     return text.replace(/<@[A-Z0-9]+>/g, '').trim();
 };
 
-const postConversionResult = async (
-    visibility: 'public' | 'ephemeral',
-    args: {
-        client: SlackClient;
-        channel: string;
-        userId: string;
-        token: string;
-        blocks: SlackBlocks;
-        say: (message: { text: string; blocks: SlackBlocks }) => Promise<unknown>;
-    },
+const noConversionMessage = async (
+    client: Helpers.SlackWebClient,
+    channel: string,
+    userId: string,
+    token: string,
+    text: string,
 ): Promise<void> => {
-    const message = { text: 'time conversion message', blocks: args.blocks };
-
-    if (visibility === 'ephemeral') {
-        await Helpers.sendEphemeralMessage(args.client, {
-            ...message,
-            channel: args.channel,
-            user: args.userId,
-            token: args.token,
-        });
-        return;
-    }
-
-    await args.say(message);
+    await Helpers.sendEphemeralMessage(client, { text, channel, user: userId, token });
 };
 
 /**
@@ -67,42 +47,43 @@ export const handleAppMention: Middleware<SlackEventMiddlewareArgs<'app_mention'
         );
 
         if (!timeContext) {
-            await Helpers.sendEphemeralMessage(client, {
-                text: 'I could not find a time reference in your message. Try something like "meeting at 3pm tomorrow".',
-                channel: channelId,
-                user: userId,
+            await noConversionMessage(
+                client,
+                channelId,
+                userId,
                 token,
-            });
+                'I could not find a time reference in your message. Try something like "meeting at 3pm tomorrow".',
+            );
             return;
         }
 
         const channelMembers = await Helpers.getConversationMembers(client, channelId, token);
-        const channelTimezones = _.filter(
-            Helpers.getUserTimeZones(channelMembers),
-            (timezone) => timezone !== timeContext.content[0].tz,
-        );
+        const prepared = prepareChannelConversion(timeContext, channelMembers);
 
-        if (channelTimezones.length === 0) {
-            await Helpers.sendEphemeralMessage(client, {
-                text: 'Everyone in this channel appears to share the same timezone.',
-                channel: channelId,
-                user: userId,
+        if (!prepared) {
+            await noConversionMessage(
+                client,
+                channelId,
+                userId,
                 token,
-            });
+                'Everyone in this channel appears to share the same timezone.',
+            );
             return;
         }
 
-        const convertedTimes = Helpers.convertTimeAcrossChannel(timeContext, channelTimezones);
-        const blocks = Views.convertedTimesBlock(timeContext.content[0].tz, convertedTimes);
         const teamId = context.teamId ?? '';
         const settings = await getWorkspaceSettings(teamId);
 
-        await postConversionResult(settings.conversionVisibility, {
+        await deliverConversion(settings.conversionVisibility, {
             client,
             channel: channelId,
-            userId,
+            triggerUserId: userId,
             token,
-            blocks,
+            timeContext,
+            members: channelMembers,
+            sourceTimezone: prepared.sourceTimezone,
+            groups: prepared.groups,
+            blocks: prepared.blocks,
             say,
         });
     } catch (err) {
@@ -156,12 +137,9 @@ export const handleConvertCommand: Middleware<SlackCommandMiddlewareArgs> = asyn
         }
 
         const channelMembers = await Helpers.getConversationMembers(client, command.channel_id, token);
-        const channelTimezones = _.filter(
-            Helpers.getUserTimeZones(channelMembers),
-            (timezone) => timezone !== timeContext.content[0].tz,
-        );
+        const prepared = prepareChannelConversion(timeContext, channelMembers);
 
-        if (channelTimezones.length === 0) {
+        if (!prepared) {
             await respond({
                 response_type: 'ephemeral',
                 text: 'Everyone in this channel appears to share the same timezone.',
@@ -169,26 +147,20 @@ export const handleConvertCommand: Middleware<SlackCommandMiddlewareArgs> = asyn
             return;
         }
 
-        const convertedTimes = Helpers.convertTimeAcrossChannel(timeContext, channelTimezones);
-        const blocks = Views.convertedTimesBlock(timeContext.content[0].tz, convertedTimes);
         const teamId = context.teamId ?? command.team_id;
         const settings = await getWorkspaceSettings(teamId);
 
-        if (settings.conversionVisibility === 'ephemeral') {
-            await Helpers.sendEphemeralMessage(client, {
-                text: 'time conversion message',
-                blocks,
-                channel: command.channel_id,
-                user: command.user_id,
-                token,
-            });
-            return;
-        }
-
-        await respond({
-            response_type: 'in_channel',
-            text: 'time conversion message',
-            blocks,
+        await deliverConversion(settings.conversionVisibility, {
+            client,
+            channel: command.channel_id,
+            triggerUserId: command.user_id,
+            token,
+            timeContext,
+            members: channelMembers,
+            sourceTimezone: prepared.sourceTimezone,
+            groups: prepared.groups,
+            blocks: prepared.blocks,
+            respond,
         });
     } catch (err) {
         getLogger().error({ err, channel: command.channel_id }, 'Failed to handle /convert command');

--- a/src/controller/workspaceSettings.ts
+++ b/src/controller/workspaceSettings.ts
@@ -1,4 +1,4 @@
-import { Middleware, SlackActionMiddlewareArgs, BlockAction, StaticSelectAction } from '@slack/bolt';
+import { Middleware, SlackActionMiddlewareArgs, BlockAction, StaticSelectAction, webApi } from '@slack/bolt';
 import { getLogger } from '../config';
 import {
     getWorkspaceSettings,
@@ -8,6 +8,24 @@ import {
 } from '../service/workspaceSettings';
 import * as View from '../view';
 import { Users } from '../model';
+
+const refreshAppHome = async (client: webApi.WebClient, userId: string, teamId: string) => {
+    const userInfo = (await client.users.info({ user: userId, include_locale: true })) as Users.InfoResponse;
+    const settings = await getWorkspaceSettings(teamId);
+    const homeBlock = View.appHomeBlock({
+        userInfo: userInfo.user,
+        settings,
+        settingsEditable: true,
+    });
+
+    await client.views.publish({
+        user_id: userId,
+        view: {
+            type: 'home',
+            blocks: homeBlock,
+        },
+    });
+};
 
 export const updateConversionVisibility: Middleware<
     SlackActionMiddlewareArgs<BlockAction<StaticSelectAction>>
@@ -24,22 +42,32 @@ export const updateConversionVisibility: Middleware<
         const visibility = action.selected_option.value as ConversionVisibility;
         await saveWorkspaceSettings(teamId, { conversionVisibility: visibility });
 
-        const userInfo = (await client.users.info({ user: userId, include_locale: true })) as Users.InfoResponse;
-        const settings = await getWorkspaceSettings(teamId);
-        const homeBlock = View.appHomeBlock({
-            userInfo: userInfo.user,
-            settings,
-            settingsEditable: true,
-        });
-
-        await client.views.publish({
-            user_id: userId,
-            view: {
-                type: 'home',
-                blocks: homeBlock,
-            },
-        });
+        await refreshAppHome(client, userId, teamId);
     } catch (err) {
         getLogger().error({ err }, 'Failed to update conversion visibility setting');
+    }
+};
+
+export const updateAutoConvert: Middleware<SlackActionMiddlewareArgs<BlockAction<StaticSelectAction>>> = async ({
+    body,
+    ack,
+    client,
+    action,
+}) => {
+    await ack();
+
+    try {
+        const teamId = body.team?.id;
+        const userId = body.user.id;
+
+        if (!teamId) throw new Error('Team ID not found in action payload');
+        if (!isSettingsEditable()) throw new Error('Workspace settings are not editable in this deployment');
+
+        const autoConvert = action.selected_option.value === 'true';
+        await saveWorkspaceSettings(teamId, { autoConvert });
+
+        await refreshAppHome(client, userId, teamId);
+    } catch (err) {
+        getLogger().error({ err }, 'Failed to update auto-convert setting');
     }
 };

--- a/src/helper/convertTime.ts
+++ b/src/helper/convertTime.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { EventContext } from '../model';
 import { assertValidTimezone, convertInstantToZone } from './timezone';
 
+/** @deprecated Use buildConversionGroups for member-aware output */
 export const convertTimeAcrossChannel = (
     timeContext: EventContext.MessageTimeContext,
     channelTimezones: string[],
@@ -15,4 +16,10 @@ export const convertTimeAcrossChannel = (
             tz: timezone,
         })),
     );
+};
+
+export const conversionGroupsToLegacyFormat = (
+    groups: { times: EventContext.DateReference[] }[],
+): EventContext.DateReference[][] => {
+    return groups.map((group) => group.times);
 };

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -7,3 +7,4 @@ export * from './timezone';
 export * from './detectTimezoneInText';
 export * from './convertTime';
 export * from './timeContext';
+export * from './memberTimezones';

--- a/src/helper/memberTimezones.ts
+++ b/src/helper/memberTimezones.ts
@@ -1,0 +1,82 @@
+import _ from 'lodash';
+import { Users, EventContext } from '../model';
+import { assertValidTimezone, convertInstantToZone, resolveTimezone } from './timezone';
+
+export interface TimezoneMemberGroup {
+    timezone: string;
+    members: Users.User[];
+    times: EventContext.DateReference[];
+}
+
+export const groupMembersByTimezone = (members: Users.User[]): Map<string, Users.User[]> => {
+    const groups = new Map<string, Users.User[]>();
+
+    for (const member of members) {
+        try {
+            const timezone = resolveTimezone(member.tz);
+            const existing = groups.get(timezone) ?? [];
+            existing.push(member);
+            groups.set(timezone, existing);
+        } catch {
+            // Skip members with invalid timezone labels
+        }
+    }
+
+    return groups;
+};
+
+export const memberDisplayName = (member: Users.User): string => {
+    return member.profile?.display_name || member.real_name || member.name;
+};
+
+export const memberMention = (member: Users.User): string => {
+    return `<@${member.id}>`;
+};
+
+export const buildConversionGroups = (
+    timeContext: EventContext.MessageTimeContext,
+    channelMembers: Users.User[],
+): TimezoneMemberGroup[] => {
+    const sourceTimezone = assertValidTimezone(timeContext.content[0].tz);
+    const grouped = groupMembersByTimezone(channelMembers);
+
+    return [...grouped.entries()]
+        .filter(([timezone]) => timezone !== sourceTimezone)
+        .map(([timezone, members]) => ({
+            timezone,
+            members,
+            times: timeContext.content.map((reference) => ({
+                start: convertInstantToZone(reference.start, timezone),
+                tz: timezone,
+            })),
+        }))
+        .sort((a, b) => a.timezone.localeCompare(b.timezone));
+};
+
+export const findMemberTimezone = (member: Users.User): string | null => {
+    try {
+        return resolveTimezone(member.tz);
+    } catch {
+        return null;
+    }
+};
+
+export const getMemberConversionTimes = (
+    timeContext: EventContext.MessageTimeContext,
+    member: Users.User,
+): EventContext.DateReference[] | null => {
+    const timezone = findMemberTimezone(member);
+    if (!timezone) return null;
+
+    const sourceTimezone = assertValidTimezone(timeContext.content[0].tz);
+    if (timezone === sourceTimezone) return null;
+
+    return timeContext.content.map((reference) => ({
+        start: convertInstantToZone(reference.start, timezone),
+        tz: timezone,
+    }));
+};
+
+export const uniqueChannelTimezones = (groups: TimezoneMemberGroup[]): string[] => {
+    return _.uniq(groups.map((group) => group.timezone));
+};

--- a/src/service/conversionDelivery.ts
+++ b/src/service/conversionDelivery.ts
@@ -1,0 +1,88 @@
+import * as Helpers from '../helper';
+import * as Views from '../view';
+import { ConversionVisibility } from './workspaceSettings';
+import { EventContext, Users } from '../model';
+import { buildConversionGroups, getMemberConversionTimes, type TimezoneMemberGroup } from '../helper/memberTimezones';
+import type { SayFn } from '@slack/bolt';
+
+type SlackBlocks = ReturnType<typeof Views.convertedTimesBlock>;
+type SlackClient = Helpers.SlackWebClient;
+
+interface DeliveryContext {
+    client: SlackClient;
+    channel: string;
+    triggerUserId: string;
+    token: string;
+    timeContext: EventContext.MessageTimeContext;
+    members: Users.User[];
+    sourceTimezone: string;
+    groups: TimezoneMemberGroup[];
+    blocks: SlackBlocks;
+    say?: SayFn;
+    respond?: (message: Record<string, unknown>) => Promise<unknown>;
+}
+
+const deliverPerMember = async (ctx: DeliveryContext): Promise<void> => {
+    const recipients = ctx.members.filter((member) => getMemberConversionTimes(ctx.timeContext, member) !== null);
+
+    await Promise.all(
+        recipients.map(async (member) => {
+            const times = getMemberConversionTimes(ctx.timeContext, member);
+            if (!times) return;
+
+            const blocks = Views.personalConversionBlock(ctx.timeContext, member, times);
+
+            await Helpers.sendEphemeralMessage(ctx.client, {
+                text: 'Your local time conversion',
+                blocks,
+                channel: ctx.channel,
+                user: member.id,
+                token: ctx.token,
+            });
+        }),
+    );
+};
+
+export const deliverConversion = async (visibility: ConversionVisibility, ctx: DeliveryContext): Promise<void> => {
+    const message = { text: 'time conversion message', blocks: ctx.blocks };
+
+    if (visibility === 'per_member') {
+        await deliverPerMember(ctx);
+        return;
+    }
+
+    if (visibility === 'ephemeral') {
+        await Helpers.sendEphemeralMessage(ctx.client, {
+            ...message,
+            channel: ctx.channel,
+            user: ctx.triggerUserId,
+            token: ctx.token,
+        });
+        return;
+    }
+
+    if (ctx.say) {
+        await ctx.say(message);
+        return;
+    }
+
+    if (ctx.respond) {
+        await ctx.respond({ ...message, response_type: 'in_channel' });
+    }
+};
+
+export const prepareChannelConversion = (
+    timeContext: EventContext.MessageTimeContext,
+    members: Users.User[],
+): { sourceTimezone: string; groups: TimezoneMemberGroup[]; blocks: SlackBlocks } | null => {
+    const groups = buildConversionGroups(timeContext, members);
+    if (groups.length === 0) return null;
+
+    const sourceTimezone = timeContext.content[0].tz;
+
+    return {
+        sourceTimezone,
+        groups,
+        blocks: Views.convertedTimesBlock(sourceTimezone, groups),
+    };
+};

--- a/src/service/workspaceSettings.ts
+++ b/src/service/workspaceSettings.ts
@@ -1,14 +1,15 @@
 import type { Firestore } from '@google-cloud/firestore';
 import type { Env } from '../config/env';
 
-export type ConversionVisibility = 'public' | 'ephemeral';
+export type ConversionVisibility = 'public' | 'ephemeral' | 'per_member';
 
 export interface WorkspaceSettings {
     conversionVisibility: ConversionVisibility;
+    autoConvert: boolean;
 }
 
 const COLLECTION = 'workspace-settings';
-const DEFAULT_SETTINGS: WorkspaceSettings = { conversionVisibility: 'public' };
+const DEFAULT_SETTINGS: WorkspaceSettings = { conversionVisibility: 'public', autoConvert: false };
 
 let settingsDb: Firestore | null = null;
 let settingsEnv: Env | null = null;
@@ -20,29 +21,46 @@ export const initWorkspaceSettings = (db: Firestore | null, env: Env): void => {
 
 export const isSettingsEditable = (): boolean => settingsDb !== null;
 
+const parseVisibility = (value: unknown): ConversionVisibility => {
+    if (value === 'ephemeral' || value === 'per_member') return value;
+    return 'public';
+};
+
 const visibilityFromEnv = (): ConversionVisibility => {
-    const value = settingsEnv?.CONVERSION_MESSAGE_VISIBILITY;
-    return value === 'ephemeral' ? 'ephemeral' : 'public';
+    return parseVisibility(settingsEnv?.CONVERSION_MESSAGE_VISIBILITY);
+};
+
+const autoConvertFromEnv = (): boolean => {
+    return settingsEnv?.AUTO_CONVERT ?? false;
 };
 
 export const getWorkspaceSettings = async (teamId: string): Promise<WorkspaceSettings> => {
     if (!settingsDb) {
-        return { conversionVisibility: visibilityFromEnv() };
+        return {
+            conversionVisibility: visibilityFromEnv(),
+            autoConvert: autoConvertFromEnv(),
+        };
     }
 
     const doc = await settingsDb.collection(COLLECTION).doc(teamId).get();
     if (!doc.exists) return DEFAULT_SETTINGS;
 
     const data = doc.data() as Partial<WorkspaceSettings> | undefined;
-    const visibility = data?.conversionVisibility === 'ephemeral' ? 'ephemeral' : 'public';
 
-    return { conversionVisibility: visibility };
+    return {
+        conversionVisibility: parseVisibility(data?.conversionVisibility),
+        autoConvert: data?.autoConvert === true,
+    };
 };
 
-export const saveWorkspaceSettings = async (teamId: string, settings: WorkspaceSettings): Promise<void> => {
+export const saveWorkspaceSettings = async (teamId: string, partial: Partial<WorkspaceSettings>): Promise<void> => {
     if (!settingsDb) {
         throw new Error('Workspace settings require Firebase in multi-workspace mode');
     }
 
-    await settingsDb.collection(COLLECTION).doc(teamId).set(settings, { merge: true });
+    const current = await getWorkspaceSettings(teamId);
+    await settingsDb
+        .collection(COLLECTION)
+        .doc(teamId)
+        .set({ ...current, ...partial }, { merge: true });
 };

--- a/src/view/appHomeBlock.ts
+++ b/src/view/appHomeBlock.ts
@@ -15,12 +15,27 @@ export const appHomeBlock = (props: HomeBlockProps) => {
 
     const visibilityOptions = [
         {
-            text: { type: 'plain_text' as const, text: 'Public — post conversions in the channel' },
+            text: { type: 'plain_text' as const, text: 'Public — post in channel' },
             value: 'public',
         },
         {
-            text: { type: 'plain_text' as const, text: 'Ephemeral — only visible to the person who triggered it' },
+            text: { type: 'plain_text' as const, text: 'Ephemeral — only the triggerer sees it' },
             value: 'ephemeral',
+        },
+        {
+            text: { type: 'plain_text' as const, text: 'Per member — each person gets their local time privately' },
+            value: 'per_member',
+        },
+    ];
+
+    const autoConvertOptions = [
+        {
+            text: { type: 'plain_text' as const, text: 'Ask before converting' },
+            value: 'false',
+        },
+        {
+            text: { type: 'plain_text' as const, text: 'Convert automatically' },
+            value: 'true',
         },
     ];
 
@@ -33,7 +48,15 @@ export const appHomeBlock = (props: HomeBlockProps) => {
                   type: 'section' as const,
                   text: {
                       type: 'mrkdwn' as const,
-                      text: '*Workspace settings*\nChoose how converted times are posted after confirmation or direct conversion.',
+                      text: '*Workspace settings*\nControl how time conversions are delivered in channels.',
+                  },
+              },
+              {
+                  type: 'section' as const,
+                  block_id: 'conversion_visibility',
+                  text: {
+                      type: 'mrkdwn' as const,
+                      text: '*Conversion visibility*',
                   },
                   accessory: {
                       type: 'static_select' as const,
@@ -48,6 +71,26 @@ export const appHomeBlock = (props: HomeBlockProps) => {
                       options: visibilityOptions,
                   },
               },
+              {
+                  type: 'section' as const,
+                  block_id: 'auto_convert',
+                  text: {
+                      type: 'mrkdwn' as const,
+                      text: '*Channel messages*\nWhen someone mentions a time, should the bot convert immediately or ask first?',
+                  },
+                  accessory: {
+                      type: 'static_select' as const,
+                      action_id: 'set_auto_convert',
+                      placeholder: {
+                          type: 'plain_text' as const,
+                          text: 'Auto-convert behavior',
+                      },
+                      initial_option: autoConvertOptions.find(
+                          (option) => option.value === String(props.settings.autoConvert),
+                      ),
+                      options: autoConvertOptions,
+                  },
+              },
           ]
         : [
               {
@@ -55,7 +98,7 @@ export const appHomeBlock = (props: HomeBlockProps) => {
                   elements: [
                       {
                           type: 'mrkdwn' as const,
-                          text: `Conversion messages are set to *${props.settings.conversionVisibility}* via server configuration.`,
+                          text: `Settings: visibility *${props.settings.conversionVisibility}*, auto-convert *${props.settings.autoConvert ? 'on' : 'off'}* (via server configuration).`,
                       },
                   ],
               },

--- a/src/view/convertedTimesBlock.ts
+++ b/src/view/convertedTimesBlock.ts
@@ -1,34 +1,29 @@
-import { EventContext } from '../model';
-import _ from 'lodash';
+import { EventContext, Users } from '../model';
 import { dateToUl } from '../helper';
+import { memberMention, type TimezoneMemberGroup } from '../helper/memberTimezones';
 
-/**
- * Converts the time information into a formatted markdown section block for Slack.
- * @param timezone the timezone label to display
- * @param localTime list of dates to display
- */
-const dateSectionBlock = (timezone: string, localTime: EventContext.DateReference[]) => {
-    const timeUlMd = _.map(localTime, (i) => dateToUl(i));
+const groupSectionBlock = (group: TimezoneMemberGroup) => {
+    const memberList = group.members.map((member) => memberMention(member)).join(', ');
+    const timeList = group.times.map((entry) => dateToUl(entry)).join('');
+
     return {
         type: 'section',
         text: {
             type: 'mrkdwn',
-            text: `*${timezone}*${timeUlMd}`,
+            text: `*${group.timezone}* (${memberList})${timeList}`,
         },
     };
 };
 
-export const convertedTimesBlock = (sourceTimezone: string, localTimes: EventContext.DateReference[][]) => {
-    const convertedBlocks = _.map(localTimes, (entries) => {
-        return dateSectionBlock(entries[0].tz, entries);
-    });
+export const convertedTimesBlock = (sourceTimezone: string, groups: TimezoneMemberGroup[]) => {
+    const convertedBlocks = groups.map((group) => groupSectionBlock(group));
 
-    const messageBlock = [
+    return [
         {
             type: 'section',
             text: {
                 type: 'mrkdwn',
-                text: `Converted time from ${sourceTimezone}`,
+                text: `Converted time from *${sourceTimezone}*`,
             },
         },
         ...convertedBlocks,
@@ -37,10 +32,35 @@ export const convertedTimesBlock = (sourceTimezone: string, localTimes: EventCon
             elements: [
                 {
                     type: 'mrkdwn',
-                    text: 'Found an issue? Please consider opening a bug report from the *App Home*!',
+                    text: 'Found an issue? Please open a bug report from the *App Home*!',
                 },
             ],
         },
     ];
-    return messageBlock;
+};
+
+export const personalConversionBlock = (
+    timeContext: EventContext.MessageTimeContext,
+    member: Users.User,
+    times: EventContext.DateReference[],
+) => {
+    const timeList = times.map((entry) => dateToUl(entry)).join('');
+    const sourceMsg = timeContext.content[0]?.sourceMsg ?? 'a time reference';
+
+    return [
+        {
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: `Hi ${memberMention(member)}! Someone shared a time in this channel:\n>${sourceMsg}`,
+            },
+        },
+        {
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: `*Your local time* (${times[0]?.tz ?? 'unknown'}):${timeList}`,
+            },
+        },
+    ];
 };

--- a/tests/messageParsing.test.ts
+++ b/tests/messageParsing.test.ts
@@ -1,12 +1,24 @@
 import { detectTimezoneInText } from '../src/helper/detectTimezoneInText';
 import * as Helpers from '../src/helper';
 import { DateTime } from 'luxon';
+import { Users } from '../src/model';
 
 const DATE_FORMAT = 'yyyy-MM-dd hh:mm a';
 
 const formatDateString = (date: Date, zone: string) => {
     return DateTime.fromJSDate(date, { zone }).toFormat(DATE_FORMAT);
 };
+
+const mockUser = (id: string, tz: string): Users.User =>
+    ({
+        id,
+        tz,
+        name: id,
+        real_name: id,
+        profile: { display_name: id },
+        is_bot: false,
+        deleted: false,
+    }) as Users.User;
 
 beforeAll(() => {
     process.env.SLACK_SIGNING_SECRET = 'my-test-secret';
@@ -95,6 +107,56 @@ describe('getUserTimeZones', () => {
         ]);
 
         expect(timezones).toEqual(['Asia/Tokyo', 'America/New_York']);
+    });
+});
+
+describe('member timezone grouping', () => {
+    it('should group channel members by timezone and exclude the source zone', () => {
+        const members = [
+            mockUser('U1', 'America/New_York'),
+            mockUser('U2', 'Asia/Tokyo'),
+            mockUser('U3', 'Asia/Tokyo'),
+        ];
+
+        const timeContext = {
+            senderId: 'U1',
+            sentChannel: 'C1',
+            sentTime: 0,
+            content: [
+                {
+                    sourceMsg: '3pm',
+                    start: new Date('2021-05-02T19:00:00.000Z'),
+                    tz: 'America/New_York',
+                },
+            ],
+        };
+
+        const groups = Helpers.buildConversionGroups(timeContext, members);
+
+        expect(groups).toHaveLength(1);
+        expect(groups[0].timezone).toEqual('Asia/Tokyo');
+        expect(groups[0].members).toHaveLength(2);
+    });
+
+    it('should identify personal conversion times for members in other zones', () => {
+        const member = mockUser('U2', 'Asia/Tokyo');
+        const timeContext = {
+            senderId: 'U1',
+            sentChannel: 'C1',
+            sentTime: 0,
+            content: [
+                {
+                    sourceMsg: '3pm EST',
+                    start: new Date('2021-05-02T19:00:00.000Z'),
+                    tz: 'America/New_York',
+                },
+            ],
+        };
+
+        const times = Helpers.getMemberConversionTimes(timeContext, member);
+
+        expect(times).not.toBeNull();
+        expect(times?.[0].tz).toEqual('Asia/Tokyo');
     });
 });
 

--- a/tests/workspaceSettings.test.ts
+++ b/tests/workspaceSettings.test.ts
@@ -10,21 +10,45 @@ describe('workspace settings', () => {
 
     it('should use env default visibility in single-workspace mode', async () => {
         process.env.CONVERSION_MESSAGE_VISIBILITY = 'ephemeral';
+        delete process.env.AUTO_CONVERT;
         const env = loadEnv();
         initWorkspaceSettings(null, env);
 
         const settings = await getWorkspaceSettings('T123');
 
         expect(settings.conversionVisibility).toEqual('ephemeral');
+        expect(settings.autoConvert).toEqual(false);
     });
 
-    it('should default to public visibility when env is unset', async () => {
+    it('should support per_member visibility from env', async () => {
+        process.env.CONVERSION_MESSAGE_VISIBILITY = 'per_member';
+        const env = loadEnv();
+        initWorkspaceSettings(null, env);
+
+        const settings = await getWorkspaceSettings('T123');
+
+        expect(settings.conversionVisibility).toEqual('per_member');
+    });
+
+    it('should read auto-convert from env', async () => {
+        process.env.AUTO_CONVERT = 'true';
+        const env = loadEnv();
+        initWorkspaceSettings(null, env);
+
+        const settings = await getWorkspaceSettings('T123');
+
+        expect(settings.autoConvert).toEqual(true);
+    });
+
+    it('should default to public visibility and no auto-convert when env is unset', async () => {
         delete process.env.CONVERSION_MESSAGE_VISIBILITY;
+        delete process.env.AUTO_CONVERT;
         const env = loadEnv();
         initWorkspaceSettings(null, env);
 
         const settings = await getWorkspaceSettings('T123');
 
         expect(settings.conversionVisibility).toEqual('public');
+        expect(settings.autoConvert).toEqual(false);
     });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 6 completes the product vision from the README: conversions are now **member-aware**, and delivery can be tailored per person.

### Member-aware conversion output

Conversion messages now group results by timezone and list the channel members in each zone (e.g. `*Asia/Tokyo* (@alice, @bob)` with formatted local times).

### Per-member delivery mode

A third visibility option joins public and ephemeral:

| Mode | Behavior |
|------|----------|
| **public** | Post full conversion in channel (unchanged) |
| **ephemeral** | Only the triggerer sees the conversion (unchanged) |
| **per_member** | Each member in a different timezone gets a private ephemeral message with their local time |

### Auto-convert

Workspace admins can enable auto-convert so channel messages with time references are converted immediately without the confirmation prompt. Configurable from App Home (Firebase mode) or via `AUTO_CONVERT=true` env var (single-workspace mode).

### Shared delivery service

All conversion paths (confirmation button, app mention, `/convert`, auto-convert) now use a shared `conversionDelivery` service for consistent behavior.

## Configuration

New env vars for single-workspace mode (see `.env.sample`):

- `CONVERSION_MESSAGE_VISIBILITY=public|ephemeral|per_member`
- `AUTO_CONVERT=true|false`

## Verification

```bash
yarn build && yarn test && yarn lint:check
```

21 tests passing (4 new).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62d2f50e-bb30-4732-9c26-d5557206539b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62d2f50e-bb30-4732-9c26-d5557206539b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

